### PR TITLE
Add husky precommit and prepush hooks for linting and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "eslint": "^4.1.0",
     "eslint-plugin-jest": "^20.0.3",
     "eslint-plugin-react": "^7.1.0",
+    "husky": "^0.14.3",
     "react-scripts": "1.0.7"
   },
   "scripts": {
@@ -25,6 +26,8 @@
     "build": "NODE_PATH=./src react-scripts build",
     "test": "NODE_PATH=./src react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
-    "lint": "eslint src --ignore-pattern \"**/__snapshots__/**\""
+    "lint": "eslint src --ignore-pattern \"**/__snapshots__/**\"",
+    "precommit": "CI=true npm test && npm run lint",
+    "prepush": "CI=true npm test && npm run lint"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2967,6 +2967,14 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
@@ -4142,6 +4150,10 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     is-builtin-module "^1.0.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
+
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
 
 normalize-path@^2.0.1:
   version "2.1.1"
@@ -5726,6 +5738,10 @@ strip-indent@^1.0.1:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
   dependencies:
     get-stdin "^4.0.1"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Added husky to devDependences to help run arbitrary scripts on precommit/prepush.
In this case we want to run linting and tests

Example:

```shell
$ git commit -am 'example commit with issues'

husky > npm run -s precommit (node v8.0.0)

 PASS  src/features/api-calls/components/__tests__/index.spec.js
 PASS  src/layout/__tests__/index.spec.js
 PASS  src/components/forms/tests/index.spec.js
 PASS  src/features/home/__tests__/index.spec.js
 PASS  src/features/api-calls/components/__tests__/translation.spec.js
 PASS  src/api/yoda/__tests__/index.spec.js

Test Suites: 6 passed, 6 total
Tests:       9 passed, 9 total
Snapshots:   6 passed, 6 total
Time:        1.316s
Ran all test suites.

/Users/alanfoster/Documents/Shopkeep/react-refresher/src/index.js
  17:19  error  Insert `;`         prettier/prettier
  17:19  error  Missing semicolon  semi

✖ 2 problems (2 errors, 0 warnings)
  2 errors, 0 warnings potentially fixable with the `--fix` option.


husky > pre-commit hook failed (add --no-verify to bypass)
```

To skip these checks, you can still bypass it via the `--no-verify` option:

```shell
git commit -am 'example bypass' --no-verify
git push origin head --no-verify
```
