### PR TITLE
Add initial page for graphql example

### DIFF
--- a/src/features/apollo-graphql-gifs/components/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/features/apollo-graphql-gifs/components/__tests__/__snapshots__/index.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders the image list 1`] = `
+<div>
+  hello world!
+</div>
+`;

--- a/src/features/apollo-graphql-gifs/components/__tests__/index.spec.js
+++ b/src/features/apollo-graphql-gifs/components/__tests__/index.spec.js
@@ -1,0 +1,10 @@
+/* eslint-env browser */
+import React from 'react';
+import ImageList from '../';
+import renderer from 'react-test-renderer';
+
+it('renders the image list', () => {
+  const component = renderer.create(<ImageList />);
+
+  expect(component).toMatchSnapshot();
+});

--- a/src/features/apollo-graphql-gifs/components/index.js
+++ b/src/features/apollo-graphql-gifs/components/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ImageList = () => <div>hello world!</div>;
+
+ImageList.propTypes = {};
+
+export default ImageList;

--- a/src/features/apollo-graphql-gifs/containers/index.js
+++ b/src/features/apollo-graphql-gifs/containers/index.js
@@ -1,0 +1,3 @@
+import ImageList from '../components';
+
+export default ImageList;

--- a/src/layout/index.js
+++ b/src/layout/index.js
@@ -40,6 +40,16 @@ const App = ({ children }) =>
         >
           Redux List Example
         </NavLink>
+
+        <NavLink
+          exact
+          activeClassName="App-link--selected"
+          to="/apollo-graphql-gifs"
+          replace
+          className="App-link"
+        >
+          Apollo + GraphQL Gifs
+        </NavLink>
       </nav>
     </div>
     <div className="App-content">

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,12 +4,18 @@ import { Switch, Route } from 'react-router-dom';
 import Home from 'features/home';
 import YodaStateExample from 'features/yoda-state-example/containers';
 import ReduxListExample from 'features/redux-list-example/containers';
+import ApolloGraphQLGifsExample from 'features/apollo-graphql-gifs/containers';
 
 const Routes = () =>
   <Switch>
     <Route exact path="/" component={Home} />
     <Route exact path="/yoda-state-example" component={YodaStateExample} />
     <Route exact path="/redux-list-example" component={ReduxListExample} />
+    <Route
+      exact
+      path="/apollo-graphql-gifs"
+      component={ApolloGraphQLGifsExample}
+    />
     <Route path="*" component={Home} />
   </Switch>;
 


### PR DESCRIPTION
Adding the initial link on the main page for a graphql/apollo example, with the default obligatory 'hello world' text